### PR TITLE
Fix Japanese character display in terminal

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-markdown", from: "0.4.0"),
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.0"),
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm", branch: "main"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/MdSh/Views/SettingsView.swift
+++ b/Sources/MdSh/Views/SettingsView.swift
@@ -47,15 +47,21 @@ struct TerminalSettingsView: View {
             }
 
             Section {
-                HStack {
-                    Text("Preview:")
-                    Spacer()
-                    Text("The quick brown fox jumps over the lazy dog")
-                        .font(.custom(settings.terminalFontName, size: settings.terminalFontSize))
-                        .padding(8)
-                        .background(Color.black)
-                        .foregroundStyle(.green)
-                        .cornerRadius(4)
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Preview:")
+                        Spacer()
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("The quick brown fox jumps over the lazy dog")
+                        Text("日本語テスト: こんにちは世界 🎉")
+                    }
+                    .font(.custom(settings.terminalFontName, size: settings.terminalFontSize))
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.black)
+                    .foregroundStyle(.green)
+                    .cornerRadius(4)
                 }
             }
         }


### PR DESCRIPTION
  - Update SwiftTerm to main branch with CJK double-width character fix
  - Add CJK font fallback cascade (Hiragino, PingFang, etc.)
  - Add 0.1s delay before shell start to ensure proper view layout
  - Add Japanese text preview in terminal font settings