### PR TITLE
Add file modification badges to file tree and tabs

### DIFF
--- a/Sources/MdSh/MdShApp.swift
+++ b/Sources/MdSh/MdShApp.swift
@@ -121,6 +121,21 @@ final class AppState {
     // Comment focus for highlighting in ReviewPanel
     var focusedCommentId: UUID?
 
+    // Track files modified during this session (by external tools like Claude)
+    var modifiedFiles: Set<URL> = []
+
+    func markFileModified(_ url: URL) {
+        modifiedFiles.insert(url)
+    }
+
+    func markFilesModified(_ urls: [URL]) {
+        modifiedFiles.formUnion(urls)
+    }
+
+    func isFileModified(_ url: URL) -> Bool {
+        modifiedFiles.contains(url)
+    }
+
     // Terminal input handler
     var terminalSendHandler: ((String) -> Void)?
 
@@ -142,6 +157,9 @@ final class AppState {
     }
 
     func openFile(_ url: URL) {
+        // Clear modified flag when file is opened
+        modifiedFiles.remove(url)
+
         // Check if already open
         if let existing = openTabs.first(where: { $0.url == url }) {
             activeTabID = existing.id

--- a/Sources/MdSh/Views/ContentView.swift
+++ b/Sources/MdSh/Views/ContentView.swift
@@ -136,17 +136,30 @@ struct TabButton: View {
         tab.id == appState.activeTabID
     }
 
+    private var isModified: Bool {
+        appState.isFileModified(tab.url)
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             // Main tab area - select button
             Button {
                 appState.activeTabID = tab.id
+                // Clear modified flag when tab is clicked
+                appState.modifiedFiles.remove(tab.url)
             } label: {
-                Text(tab.name)
-                    .lineLimit(1)
-                    .padding(.leading, 12)
-                    .padding(.trailing, 4)
-                    .padding(.vertical, 6)
+                HStack(spacing: 4) {
+                    Text(tab.name)
+                        .lineLimit(1)
+                    if isModified {
+                        Circle()
+                            .fill(.blue)
+                            .frame(width: 8, height: 8)
+                    }
+                }
+                .padding(.leading, 12)
+                .padding(.trailing, 4)
+                .padding(.vertical, 6)
             }
             .buttonStyle(.plain)
 

--- a/Sources/MdSh/Views/FileTreeView.swift
+++ b/Sources/MdSh/Views/FileTreeView.swift
@@ -92,7 +92,10 @@ struct FileTreeView: View {
         stopDirectoryWatcher()
         let state = appState
         let url = rootURL
-        directoryWatcher = DirectoryWatcher(url: url) {
+        directoryWatcher = DirectoryWatcher(url: url) { changedFiles in
+            // Mark changed files as modified
+            state.markFilesModified(changedFiles)
+            // Refresh extensions (for new files)
             state.refreshExtensions()
         }
         directoryWatcher?.start()
@@ -202,15 +205,24 @@ struct ExtensionToggleRow: View {
 
 struct FileRowView: View {
     let item: FileItem
+    @Environment(AppState.self) private var appState
 
     var body: some View {
-        Label {
-            Text(item.name)
-                .lineLimit(1)
-                .truncationMode(.middle)
-        } icon: {
-            Image(systemName: item.iconName)
-                .foregroundStyle(item.iconColor)
+        HStack(spacing: 4) {
+            Label {
+                Text(item.name)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            } icon: {
+                Image(systemName: item.iconName)
+                    .foregroundStyle(item.iconColor)
+            }
+
+            if !item.isDirectory && appState.isFileModified(item.url) {
+                Circle()
+                    .fill(.blue)
+                    .frame(width: 8, height: 8)
+            }
         }
     }
 }


### PR DESCRIPTION
  - Track files modified during session by external tools (Claude, etc.)
  - Show blue dot indicator on modified/new files in file tree
  - Show blue dot indicator on tabs for modified files
  - Clear badge when file is opened or tab is clicked
  - Update DirectoryWatcher to report specific changed file paths